### PR TITLE
Tweak forms validation attribute generation

### DIFF
--- a/packages/forms/src/Components/Concerns/CanBeValidated.php
+++ b/packages/forms/src/Components/Concerns/CanBeValidated.php
@@ -170,7 +170,7 @@ trait CanBeValidated
 
     public function getValidationAttribute(): string
     {
-        return $this->evaluate($this->validationAttribute) ?? lcfirst($this->getLabel());
+        return $this->evaluate($this->validationAttribute) ?? strtolower($this->getLabel());
     }
 
     public function getValidationRules(): array


### PR DESCRIPTION
This commit tweaks the behaviour of the `getValidationAttribute` method for fields, to use the entire lowercased version of the field label (and therefore name, if not explicitly set) as a fallback, rather than simply lowercasing the first character.

For a label consisting of a single word, this wouldn't normally be a problem, however for labels with multiple words, aesthetically it looks better to have all words lowercased when used for error messages.

Before:
<img width="348" alt="Screen Shot 2022-03-28 at 11 38 01 am" src="https://user-images.githubusercontent.com/3736774/160312251-3da15ade-898e-463e-a593-c081158da567.png">

After:
<img width="348" alt="Screen Shot 2022-03-28 at 11 38 13 am" src="https://user-images.githubusercontent.com/3736774/160312248-18a058f9-0e5b-427e-a50f-2641662e0a0f.png">

